### PR TITLE
Fixed logic for C-Side from Completion to Gemheart.

### DIFF
--- a/worlds/celeste/progression.py
+++ b/worlds/celeste/progression.py
@@ -95,8 +95,8 @@ class DefaultProgression(BaseProgression):
         elif side == CelesteSide.C_SIDE:
             return lambda state: state.has_all(
                 {
-                    BaseData.item_name(CelesteItemType.COMPLETION, level, CelesteSide.A_SIDE),
-                    BaseData.item_name(CelesteItemType.COMPLETION, level, CelesteSide.B_SIDE),
+                    BaseData.item_name(CelesteItemType.GEMHEART, level, CelesteSide.A_SIDE),
+                    BaseData.item_name(CelesteItemType.GEMHEART, level, CelesteSide.B_SIDE),
                 },
                 player,
             )


### PR DESCRIPTION
## What is this fixing or adding?
C-Side logic was based on completion of A- and B-Sides but has to be the Gemhearts.
That fixes is based on this [Discord post](https://discord.com/channels/731205301247803413/1021069526625947729/1231093437848092772).

## How was this tested?
Played some seeds with the fixed settings and C-Side access worked properly.

## If this makes graphical changes, please attach screenshots.
