### PR TITLE
Changed additional strawberries to filler instead of useful.

### DIFF
--- a/worlds/celeste/progression.py
+++ b/worlds/celeste/progression.py
@@ -218,10 +218,10 @@ class DefaultProgression(BaseProgression):
             classification = ItemClassification.progression
             if item_type == CelesteItemType.STRAWBERRY:
                 if strawberry_count >= required_strawberries:
-                    classification = ItemClassification.useful
+                    classification = ItemClassification.filler
                 strawberry_count += 1
             elif level == self._goal_level() and side == self._goal_side() and item_type != CelesteItemType.COMPLETION:
-                classification = ItemClassification.useful
+                classification = ItemClassification.filler
 
             item = CelesteItem(
                 name=name,


### PR DESCRIPTION
## What is this fixing or adding?
Strawberries which are more then the needed amount are set to filler instead of useful if the threshold is reached.

This is based on this [Discord post](https://discord.com/channels/731205301247803413/1021069526625947729/1235996681842065449).
If it is really necessary is questioned [here](https://discord.com/channels/731205301247803413/1021069526625947729/1251828232945401887).
I've PR it so this change is not getting lost in case it should be used.

## How was this tested?
Played some seeds with the fixed world and the strawberries were shown either progression or filler.

## If this makes graphical changes, please attach screenshots.
